### PR TITLE
Switch Alt+Left/Right to Ctrl+Left/Right for navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ It’s capable of making websites appear and behave more like native OS applicat
 - `Ctrl + L`: Lock/unlock window geometry
 - `Ctrl + Q`, `Ctrl + W`: Close the app
 - `Ctrl + <click>`: Open link using system’s browser
-- `Alt + Left`, `Backspace`: Go one step back
-- `Alt + Right`: Go one step forward
+- `Ctrl + Left`, `Backspace`: Go one step back
+- `Ctrl + Right`: Go one step forward
 
 
 ## Build

--- a/inc/globals.h
+++ b/inc/globals.h
@@ -47,9 +47,9 @@ e.g.: ShowScrollBars, Icon, ZoomLevel, etc.
 
 /* Keyboard shortcuts (all windows and dialog boxes) */
 #define LQD_KBD_SEQ_MUTE_AUDIO           "Ctrl+M"
-#define LQD_KBD_SEQ_GO_BACK              "Alt+Left"
+#define LQD_KBD_SEQ_GO_BACK              "Ctrl+Left"
 #define LQD_KBD_SEQ_GO_BACK_2            "Backspace"
-#define LQD_KBD_SEQ_GO_FORWARD           "Alt+Right"
+#define LQD_KBD_SEQ_GO_FORWARD           "Ctrl+Right"
 #define LQD_KBD_SEQ_RELOAD               "Ctrl+R"
 #define LQD_KBD_SEQ_RELOAD_2             "F5"
 #define LQD_KBD_SEQ_HARD_RELOAD          "Ctrl+Shift+R"


### PR DESCRIPTION
No idea why Firefox and others use Alt instead of Ctrl, maybe I'm missing something.  Makes sense to steer away from involving Alt just for two actions, and center around Ctrl.